### PR TITLE
build: add cupy optional dependency

### DIFF
--- a/src/Python/pyproject.toml
+++ b/src/Python/pyproject.toml
@@ -10,3 +10,5 @@ include = ["ccpi", "ccpi.*"]
 version = "24.0.0"
 name = "ccpi-regulariser"
 dependencies = ["numpy"]
+[project.optional-dependencies]
+gpu = ["cupy"]


### PR DESCRIPTION
Leaving this undocumented for now as it's not really very usable yet (`cmake ... --target install && pip install ./src/Python[gpu]`). Opening the PR so I don't forget.

Proper docs & usage will be part of #198 (`pip install ccpi-regulariser[gpu]`).
